### PR TITLE
Fix infinte loop in cm_destroy_source

### DIFF
--- a/src/cmixer.c
+++ b/src/cmixer.c
@@ -389,6 +389,7 @@ void cm_destroy_source(cm_Source *src) {
         *s = src->next;
         break;
       }
+      s = &((*s)->next);
     }
   }
   unlock();


### PR DESCRIPTION
There was no step towards the next element in the linked list in the while loop, that caused a hang when destroying one of several sources